### PR TITLE
Add Prefetch as a Resource Hint Option

### DIFF
--- a/Block/Adminhtml/Form/Field/ResourceHintType.php
+++ b/Block/Adminhtml/Form/Field/ResourceHintType.php
@@ -17,7 +17,8 @@ class ResourceHintType extends Select
     protected $_options = [
         'preload'      => 'Preload',
         'preconnect'   => 'Preconnect',
-        'dns-prefetch' => 'DNS Prefetch'
+        'prefetch'    => 'Prefetch',
+        'dns-prefetch' => 'DNS Prefetch',
     ];
 
     /**

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-Add `<link rel='preconnect'>`, `<link rel='dns-prefetch'>` or `<link rel='preload'>` resource hints to Magento 2's head.
+Add `<link rel='preconnect'>`, `<link rel='dns-prefetch'>`, `<link rel='prefetch'>`,  or `<link rel='preload'>` resource hints to Magento 2's head.
 
 ## Features
 
-- Tweak your Magento 2 store's performance by adding custom `preconnect`, `dns-prefetch` and `preload` headers.
+- Tweak your Magento 2 store's performance by adding custom `preconnect`, `dns-prefetch`, `prefetch`, and `preload` headers.
 - Enable/disable `crossorigin` attribute.
 - Easily configurable at default, website and store view level (incl. sort order).
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "dan0sz/resource-hints-magento2",
-  "description": "Add `<link rel='preconnect'>`, `<link rel='dns-prefetch'>` or `<link rel='preload'>` resource hints to Magento 2's head.",
+  "description": "Add `<link rel='preconnect'>`, `<link rel='dns-prefetch'>`, `<link rel='prefetch'>`, or `<link rel='preload'>` resource hints to Magento 2's head.",
   "version": "1.2.0",
   "require": {
     "php": "7.*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Dan0sz_ResourceHints",
   "version": "1.1.0",
-  "description": "Add `<link rel='preconnect'>`, `<link rel='dns-prefetch'>` or `<link rel='preload'>` resource hints to Magento 2's head.",
+  "description": "Add `<link rel='preconnect'>`, `<link rel='dns-prefetch'>`, `<link rel='dns-prefetch'>`, or `<link rel='preload'>` resource hints to Magento 2's head.",
   "author": "Dan0sz",
   "license": "CC-BY-4.0",
   "homepage": "https://daan.dev/"


### PR DESCRIPTION
Currently, the module only uses dns-prefetch but we want to expand that to include link prefetch.

This PR: 
Adds `prefetch` as a Resource Hint type. 
Updates composer.json, package.json descriptions to include prefetch option.
Updates README to include prefetch option. 